### PR TITLE
Use `slice::iter` instead of `into_iter` to avoid future breakage

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -883,7 +883,7 @@ mod tests {
             .take(items.len() * 2)
             .cloned()
             .collect::<Counter<_>>();
-        let expected: HashMap<char, usize> = items.into_iter().map(|(c, n)| (*c, n * 2)).collect();
+        let expected: HashMap<char, usize> = items.iter().map(|(c, n)| (*c, n * 2)).collect();
         assert_eq!(counter.map, expected);
     }
 


### PR DESCRIPTION
`an_array.into_iter()` currently just works because of the autoref
feature, which then calls `<[T] as IntoIterator>::into_iter`. But
in the future, arrays will implement `IntoIterator`, too. In order
to avoid problems in the future, the call is replaced by `iter()`
which is shorter and more explicit.

A crater run showed that your crate is affected by a potential future 
change. See https://github.com/rust-lang/rust/pull/65819 for more information.