### PR TITLE
Added implementations for IntoIter and IterMut

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,10 +158,7 @@
 use num_traits::{One, Zero};
 
 use std::borrow::Borrow;
-use std::collections::{
-    hash_map::{IntoIter, Iter, IterMut},
-    HashMap,
-};
+use std::collections::HashMap;
 use std::hash::Hash;
 use std::iter;
 use std::ops::{Add, AddAssign, BitAnd, BitOr, Deref, DerefMut, Index, IndexMut, Sub, SubAssign};
@@ -548,9 +545,9 @@ where
     T: Hash + Eq,
 {
     type Item = (&'a T, &'a N);
-    type IntoIter = Iter<'a, T, N>;
+    type IntoIter = std::collections::hash_map::Iter<'a, T, N>;
 
-    fn into_iter(self) -> Iter<'a, T, N> {
+    fn into_iter(self) -> Self::IntoIter {
         self.map.iter()
     }
 }
@@ -560,18 +557,18 @@ where
     T: Hash + Eq,
 {
     type Item = (T, N);
-    type IntoIter = IntoIter<T, N>;
+    type IntoIter = std::collections::hash_map::IntoIter<T, N>;
 
     /// Consumes the Counter to produce an iterator that owns the values it returns
-    /// 
+    ///
     /// # Examples
     /// ```rust
     /// # use counter::Counter;
-    /// 
+    ///
     /// let counter: Counter<_> = "aaab".chars().collect();
-    /// 
+    ///
     /// let vec: Vec<_> = counter.into_iter().collect();
-    /// 
+    ///
     /// for (item, count) in &vec {
     ///     if item == &'a' {
     ///         assert_eq!(count, &3);
@@ -592,23 +589,23 @@ where
     T: Hash + Eq,
 {
     type Item = (&'a T, &'a mut N);
-    type IntoIter = IterMut<'a, T, N>;
+    type IntoIter = std::collections::hash_map::IterMut<'a, T, N>;
 
     /// Creates an iterator that provides mutable references to the counts, but keeps the key immutable
-    /// 
+    ///
     /// # Examples
     /// ```rust
     /// # use counter::Counter;
-    /// 
+    ///
     /// let mut counter: Counter<_> = "aaab".chars().collect();
-    /// 
+    ///
     /// for (item, count) in &mut counter {
     ///     if *item == 'a' {
     ///         // 'a' is so great it counts as 2
     ///         *count *= 2;
     ///     }
     /// }
-    /// 
+    ///
     /// assert_eq!(counter[&'a'], 6);
     /// assert_eq!(counter[&'b'], 1);
     /// ```


### PR DESCRIPTION
- The main goal was to add IntoIter, this allows moving the values and their count out of the counter
- It may be nicer to modify the counts manually with an iterator rather than via index.