### PR TITLE
Relax trait bounds for `Default` implementation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,7 +165,7 @@ use std::ops::{Add, AddAssign, BitAnd, BitOr, Deref, DerefMut, Index, IndexMut, 
 
 type CounterMap<T, N> = HashMap<T, N>;
 
-#[derive(Clone, PartialEq, Eq, Debug, Default)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct Counter<T: Hash + Eq, N = usize> {
     map: CounterMap<T, N>,
     // necessary for `Index::index` since we cannot declare generic `static` variables.
@@ -315,6 +315,19 @@ where
     /// ```
     pub fn most_common_ordered(&self) -> Vec<(T, N)> {
         self.most_common_tiebreaker(|a, b| a.cmp(b))
+    }
+}
+
+impl<T, N> Default for Counter<T, N>
+where
+    T: Hash + Eq,
+    N: Default,
+{
+    fn default() -> Self {
+        Self {
+            map: Default::default(),
+            zero: Default::default(),
+        }
     }
 }
 


### PR DESCRIPTION
The `Default` derive adds a `T: Default` and a `N: Default` bound on the implementation. The `T: Default` bound is however not necessary and can be removed by manually implementing `Default`.

It might also be worth to consider changing the bounds to `N: Zero`, to bring it in line with most other trait implementations. This would, however, change `Default` in non-backwards compatible ways, which is why I didn't attempt that.