### PR TITLE
Add method `Counter::total()`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,7 +160,7 @@ use num_traits::{One, Zero};
 use std::borrow::Borrow;
 use std::collections::HashMap;
 use std::hash::Hash;
-use std::iter::{self, Sum};
+use std::iter;
 use std::ops::{Add, AddAssign, BitAnd, BitOr, Deref, DerefMut, Index, IndexMut, Sub, SubAssign};
 
 type CounterMap<T, N> = HashMap<T, N>;
@@ -339,7 +339,7 @@ where
     /// ```
     pub fn total<'a, S>(&'a self) -> S
     where
-        S: Sum<&'a N>,
+        S: iter::Sum<&'a N>,
     {
         self.map.values().sum()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,7 +160,7 @@ use num_traits::{One, Zero};
 use std::borrow::Borrow;
 use std::collections::HashMap;
 use std::hash::Hash;
-use std::iter;
+use std::iter::{self, Sum};
 use std::ops::{Add, AddAssign, BitAnd, BitOr, Deref, DerefMut, Index, IndexMut, Sub, SubAssign};
 
 type CounterMap<T, N> = HashMap<T, N>;
@@ -315,6 +315,33 @@ where
     /// ```
     pub fn most_common_ordered(&self) -> Vec<(T, N)> {
         self.most_common_tiebreaker(|a, b| a.cmp(b))
+    }
+}
+
+impl<T, N> Counter<T, N>
+where
+    T: Hash + Eq,
+{
+    /// Returns the sum of the counts.
+    ///
+    /// Use [`len`] to get the number of elements in the counter and use `total` to get the sum of
+    /// their counts.
+    ///
+    /// [`len`]: struct.Counter.html#method.len
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use counter::Counter;
+    /// let counter = Counter::init("abracadabra".chars());
+    /// assert_eq!(counter.total::<usize>(), 11);
+    /// assert_eq!(counter.len(), 5);
+    /// ```
+    pub fn total<'a, S>(&'a self) -> S
+    where
+        S: Sum<&'a N>,
+    {
+        self.map.values().sum()
     }
 }
 
@@ -1066,6 +1093,17 @@ mod tests {
         let by_common = counter.most_common_ordered();
         let expected = vec![('c', 3), ('b', 2), ('d', 2), ('a', 1), ('e', 1)];
         assert!(by_common == expected);
+    }
+
+    #[test]
+    fn test_total() {
+        let counter = Counter::init("".chars());
+        let total: usize = counter.total();
+        assert_eq!(total, 0);
+
+        let counter = Counter::init("eaddbbccc".chars());
+        let total: usize = counter.total();
+        assert_eq!(total, 9);
     }
 
     #[test]


### PR DESCRIPTION
This is based on the method of the same name from Python's
[`collections.Counter`](https://docs.python.org/3/library/collections.html#collections.Counter.total), new in Python 3.10.