### PR TITLE
Relax trait bounds

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -372,7 +372,7 @@ where
 
 impl<T, N> AddAssign for Counter<T, N>
 where
-    T: Clone + Hash + Eq,
+    T: Hash + Eq,
     N: Zero + AddAssign,
 {
     /// Add another counter to this counter
@@ -392,7 +392,7 @@ where
     /// ```
     fn add_assign(&mut self, rhs: Self) {
         for (key, value) in rhs.map.into_iter() {
-            let entry = self.map.entry(key.clone()).or_insert_with(N::zero);
+            let entry = self.map.entry(key).or_insert_with(N::zero);
             *entry += value;
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -933,8 +933,8 @@ where
 
 impl<'a, T: 'a, N: 'a> Extend<(&'a T, &'a N)> for Counter<T, N>
 where
-    T: Hash + Eq + Copy,
-    N: AddAssign + Zero + Copy,
+    T: Hash + Eq + Clone,
+    N: AddAssign + Zero + Clone,
 {
     /// Extend a counter with `(item, count)` tuples.
     ///
@@ -951,8 +951,8 @@ where
     /// ```
     fn extend<I: IntoIterator<Item = (&'a T, &'a N)>>(&mut self, iter: I) {
         for (item, item_count) in iter.into_iter() {
-            let entry = self.map.entry(*item).or_insert_with(N::zero);
-            *entry += *item_count;
+            let entry = self.map.entry(item.clone()).or_insert_with(N::zero);
+            *entry += item_count.clone();
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -574,7 +574,6 @@ where
 impl<T, N> Deref for Counter<T, N>
 where
     T: Hash + Eq,
-    N: Clone,
 {
     type Target = CounterMap<T, N>;
     fn deref(&self) -> &CounterMap<T, N> {
@@ -585,7 +584,6 @@ where
 impl<T, N> DerefMut for Counter<T, N>
 where
     T: Hash + Eq,
-    N: Clone,
 {
     fn deref_mut(&mut self) -> &mut CounterMap<T, N> {
         &mut self.map
@@ -808,8 +806,8 @@ where
 impl<I, T, N> Sub<I> for Counter<T, N>
 where
     I: IntoIterator<Item = T>,
-    T: Clone + Hash + Eq,
-    N: Clone + PartialOrd + SubAssign + Zero + One,
+    T: Hash + Eq,
+    N: PartialOrd + SubAssign + Zero + One,
 {
     type Output = Self;
     /// Consume self producing a Counter like self with the counts of the


### PR DESCRIPTION
These are some proposed changes that collectively relax some of the trait bounds in the crate.  They are split into several commits so that each one can be coherent and focussed on one kind of change and in that way, hopefully, easier to review.  In some cases existing bounds can be relaxed without modifying code in the implementations; in others a minor amount of refactoring allows us to relax the bounds.

This builds on similar work in prior PRs such as #7, #17, #19.
