### PR TITLE
Relax more trait bounds

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,20 +180,6 @@ where
     pub fn into_map(self) -> HashMap<T, N> {
         self.map
     }
-}
-
-impl<T, N> Counter<T, N>
-where
-    T: Hash + Eq,
-    N: Zero,
-{
-    /// Create a new, empty `Counter`
-    pub fn new() -> Counter<T, N> {
-        Counter {
-            map: HashMap::new(),
-            zero: N::zero(),
-        }
-    }
 
     /// Returns the sum of the counts.
     ///
@@ -215,6 +201,20 @@ where
         S: iter::Sum<&'a N>,
     {
         self.map.values().sum()
+    }
+}
+
+impl<T, N> Counter<T, N>
+where
+    T: Hash + Eq,
+    N: Zero,
+{
+    /// Create a new, empty `Counter`
+    pub fn new() -> Counter<T, N> {
+        Counter {
+            map: HashMap::new(),
+            zero: N::zero(),
+        }
     }
 }
 


### PR DESCRIPTION
This PR removes the unnecessary bound `N: Zero` on the implementation of `Counter::total()`.  As part of the refactoring done in ecebdf396bd12ad4ab51a251f275cda8bfb97b3b, the `.total()` method was mistakenly moved to the wrong impl block.

It also relaxes the bound on the closure provided to `Counter::most_common_tiebreaker()` to `FnMut`, since that is all that is required by `slice::sort_by()`.