### PR TITLE
Fix minor issues in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # counter
 
-Counter counts recurrent elements of iterables. It is based on [the Python implementation](https://docs.python.org/3.5/library/collections.html#collections.Counter).
+Counter counts recurrent elements of iterables. It is based on [the Python
+implementation](https://docs.python.org/3/library/collections.html#collections.Counter).
 
 The struct [`Counter`](struct.Counter.html) is the entry-point type for this module.
 
@@ -33,6 +34,15 @@ let other_counts = "scrabble cabbie fable babble"
 let difference = counts - other_counts;
 ```
 
+Extend a `Counter` with another `Counter`:
+```rust
+let mut counter = "abbccc".chars().collect::<Counter<_>>();
+let another = "bccddd".chars().collect::<Counter<_>>();
+counter.extend(&another);
+let expect = [('a', 1), ('b', 3), ('c', 5), ('d', 3)].iter()
+    .cloned().collect::<HashMap<_, _>>();
+assert_eq!(counter.into_map(), expect);
+```
 ### Get items with keys
 
 ```rust
@@ -43,7 +53,10 @@ assert_eq!(counts[&'b'], 0);
 
 ### Get the most common items
 
-`most_common_ordered()` uses the natural ordering of keys which are `Ord`.
+[`most_common_ordered()`] uses the natural ordering of keys which are [`Ord`].
+
+[`most_common_ordered()`]: Counter::most_common_ordered
+[`Ord`]: https://doc.rust-lang.org/stable/std/cmp/trait.Ord.html
 
 ```rust
 let by_common = "eaddbbccc".chars().collect::<Counter<_>>().most_common_ordered();
@@ -62,11 +75,15 @@ let expected = vec![('c', 3), ('d', 2), ('b', 2), ('e', 1), ('a', 1)];
 assert!(by_common == expected);
 ```
 
-### Treat it like a Map
+### Treat it like a `HashMap`
 
-`Counter<T, N>` implements `Deref<Target=HashMap<T, N>>` and
-`DerefMut<Target=HashMap<T, N>>`, which means that you can perform any operations
-on it which are valid for a [`HashMap`](https://doc.rust-lang.org/std/collections/struct.HashMap.html).
+`Counter<T, N>` implements [`Deref`]`<Target=HashMap<T, N>>` and
+[`DerefMut`]`<Target=HashMap<T, N>>`, which means that you can perform any operations
+on it which are valid for a [`HashMap`].
+
+[`HashMap`]: https://doc.rust-lang.org/std/collections/struct.HashMap.html
+[`Deref`]: https://doc.rust-lang.org/stable/std/ops/trait.Deref.html
+[`DerefMut`]: https://doc.rust-lang.org/stable/std/ops/trait.DerefMut.html
 
 ```rust
 let mut counter = "aa-bb-cc".chars().collect::<Counter<_>>();
@@ -74,7 +91,11 @@ counter.remove(&'-');
 assert!(counter == "aabbcc".chars().collect::<Counter<_>>());
 ```
 
-Note that `Counter<T, N>` itself implements `Index`. `Counter::index` returns a reference to a `zero` value for missing keys.
+Note that `Counter<T, N>` itself implements [`Index`]. `Counter::index` returns a reference to
+a [`Zero::zero`] value for missing keys.
+
+[`Index`]: https://doc.rust-lang.org/stable/std/ops/trait.Index.html
+[`Zero::zero`]: https://docs.rs/num-traits/latest/num_traits/identities/trait.Zero.html#tymethod.zero
 
 ```rust
 let counter = "aaa".chars().collect::<Counter<_>>();
@@ -87,7 +108,10 @@ assert_eq!(counter[&'b'], 0);
 
 ### Count any iterable which is `Hash + Eq`
 
-You can't use the `most_common*` functions unless T is also `Clone`, but simple counting works fine on a minimal data type.
+You can't use the `most_common*` functions unless `T` is also [`Clone`], but simple counting
+works fine on a minimal data type.
+
+[`Clone`]: https://doc.rust-lang.org/stable/std/clone/trait.Clone.html
 
 ```rust
 #[derive(Debug, Hash, PartialEq, Eq)]
@@ -126,9 +150,12 @@ assert!(inty_counts.get(&Inty { i: 6 }) == Some(&1));
 
 ### Use your own type for the count
 
-Sometimes `usize` just isn't enough. If you find yourself overflowing your
-machine's native size, you can use your own type. Here, we use an `i8`, but
+Sometimes [`usize`] just isn't enough. If you find yourself overflowing your
+machine's native size, you can use your own type. Here, we use an [`i8`], but
 you can use most numeric types, including bignums, as necessary.
+
+[`usize`]: https://doc.rust-lang.org/stable/std/primitive.usize.html
+[`i8`]: https://doc.rust-lang.org/stable/std/primitive.i8.html
 
 ```rust
 let counter: Counter<_, i8> = "abbccc".chars().collect();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
-//! Counter counts recurrent elements of iterables. It is based on [the Python implementation](https://docs.python.org/3.5/library/collections.html#collections.Counter).
+//! Counter counts recurrent elements of iterables. It is based on [the Python
+//! implementation](https://docs.python.org/3/library/collections.html#collections.Counter).
 //!
 //! The struct [`Counter`](struct.Counter.html) is the entry-point type for this module.
 //!
@@ -33,7 +34,7 @@
 //! let difference = counts - other_counts;
 //! ```
 //!
-//! Extend a Counter with another Counter:
+//! Extend a `Counter` with another `Counter`:
 //! ```rust
 //! # use counter::Counter;
 //! # use std::collections::HashMap;
@@ -55,7 +56,10 @@
 //!
 //! ## Get the most common items
 //!
-//! `most_common_ordered()` uses the natural ordering of keys which are `Ord`.
+//! [`most_common_ordered()`] uses the natural ordering of keys which are [`Ord`].
+//!
+//! [`most_common_ordered()`]: Counter::most_common_ordered
+//! [`Ord`]: https://doc.rust-lang.org/stable/std/cmp/trait.Ord.html
 //!
 //! ```rust
 //! # use counter::Counter;
@@ -76,11 +80,15 @@
 //! assert!(by_common == expected);
 //! ```
 //!
-//! ## Treat it like a Map
+//! ## Treat it like a `HashMap`
 //!
-//! `Counter<T, N>` implements `Deref<Target=HashMap<T, N>>` and
-//! `DerefMut<Target=HashMap<T, N>>`, which means that you can perform any operations
-//! on it which are valid for a [`HashMap`](https://doc.rust-lang.org/std/collections/struct.HashMap.html).
+//! `Counter<T, N>` implements [`Deref`]`<Target=HashMap<T, N>>` and
+//! [`DerefMut`]`<Target=HashMap<T, N>>`, which means that you can perform any operations
+//! on it which are valid for a [`HashMap`].
+//!
+//! [`HashMap`]: https://doc.rust-lang.org/std/collections/struct.HashMap.html
+//! [`Deref`]: https://doc.rust-lang.org/stable/std/ops/trait.Deref.html
+//! [`DerefMut`]: https://doc.rust-lang.org/stable/std/ops/trait.DerefMut.html
 //!
 //! ```rust
 //! # use counter::Counter;
@@ -89,7 +97,11 @@
 //! assert!(counter == "aabbcc".chars().collect::<Counter<_>>());
 //! ```
 //!
-//! Note that `Counter<T, N>` itself implements `Index`. `Counter::index` returns a reference to a `zero` value for missing keys.
+//! Note that `Counter<T, N>` itself implements [`Index`]. `Counter::index` returns a reference to
+//! a [`Zero::zero`] value for missing keys.
+//!
+//! [`Index`]: https://doc.rust-lang.org/stable/std/ops/trait.Index.html
+//! [`Zero::zero`]: https://docs.rs/num-traits/latest/num_traits/identities/trait.Zero.html#tymethod.zero
 //!
 //! ```rust
 //! # use counter::Counter;
@@ -103,7 +115,10 @@
 //!
 //! ## Count any iterable which is `Hash + Eq`
 //!
-//! You can't use the `most_common*` functions unless T is also `Clone`, but simple counting works fine on a minimal data type.
+//! You can't use the `most_common*` functions unless `T` is also [`Clone`], but simple counting
+//! works fine on a minimal data type.
+//!
+//! [`Clone`]: https://doc.rust-lang.org/stable/std/clone/trait.Clone.html
 //!
 //! ```rust
 //! # use counter::Counter;
@@ -143,9 +158,12 @@
 //!
 //! ## Use your own type for the count
 //!
-//! Sometimes `usize` just isn't enough. If you find yourself overflowing your
-//! machine's native size, you can use your own type. Here, we use an `i8`, but
+//! Sometimes [`usize`] just isn't enough. If you find yourself overflowing your
+//! machine's native size, you can use your own type. Here, we use an [`i8`], but
 //! you can use most numeric types, including bignums, as necessary.
+//!
+//! [`usize`]: https://doc.rust-lang.org/stable/std/primitive.usize.html
+//! [`i8`]: https://doc.rust-lang.org/stable/std/primitive.i8.html
 //!
 //! ```rust
 //! # use counter::Counter;
@@ -176,7 +194,9 @@ impl<T, N> Counter<T, N>
 where
     T: Hash + Eq,
 {
-    /// Consumes this counter and returns a HashMap mapping the items to the counts.
+    /// Consumes this counter and returns a [`HashMap`] mapping the items to the counts.
+    ///
+    /// [`HashMap`]: https://doc.rust-lang.org/stable/std/collections/struct.HashMap.html
     pub fn into_map(self) -> HashMap<T, N> {
         self.map
     }
@@ -187,7 +207,7 @@ where
     T: Hash + Eq,
     N: Zero,
 {
-    /// Create a new, empty `Counter`
+    /// Create a new, empty `Counter`.
     pub fn new() -> Counter<T, N> {
         Counter {
             map: HashMap::new(),
@@ -223,7 +243,7 @@ where
     T: Hash + Eq,
     N: AddAssign + Zero + One,
 {
-    /// Create a new `Counter` initialized with the given iterable
+    /// Create a new `Counter` initialized with the given iterable.
     pub fn init<I>(iterable: I) -> Counter<T, N>
     where
         I: IntoIterator<Item = T>,
@@ -233,7 +253,7 @@ where
         counter
     }
 
-    /// Add the counts of the elements from the given iterable to this counter
+    /// Add the counts of the elements from the given iterable to this counter.
     pub fn update<I>(&mut self, iterable: I)
     where
         I: IntoIterator<Item = T>,
@@ -250,9 +270,9 @@ where
     T: Hash + Eq,
     N: PartialOrd + SubAssign + Zero + One,
 {
-    /// Remove the counts of the elements from the given iterable to this counter
+    /// Remove the counts of the elements from the given iterable to this counter.
     ///
-    /// Non-positive counts are automatically removed
+    /// Non-positive counts are automatically removed.
     ///
     /// ```rust
     /// # use counter::Counter;
@@ -375,7 +395,7 @@ where
     T: Hash + Eq,
     N: Zero + AddAssign,
 {
-    /// Add another counter to this counter
+    /// Add another counter to this counter.
     ///
     /// `c += d;` -> `c[x] += d[x]` for all `x`
     ///
@@ -434,7 +454,10 @@ where
     /// Subtract (keeping only positive values).
     ///
     /// `c -= d;` -> `c[x] -= d[x]` for all `x`,
-    /// keeping only items with a value greater than N::zero().
+    /// keeping only items with a value greater than [`N::zero()`].
+    ///
+    /// [`N::zero()`]:
+    /// https://docs.rs/num-traits/latest/num_traits/identities/trait.Zero.html#tymethod.zero
     ///
     /// ```rust
     /// # use counter::Counter;
@@ -477,7 +500,10 @@ where
     /// Subtract (keeping only positive values).
     ///
     /// `out = c - d;` -> `out[x] == c[x] - d[x]` for all `x`,
-    /// keeping only items with a value greater than N::zero().
+    /// keeping only items with a value greater than [`N::zero()`].
+    ///
+    /// [`N::zero()`]:
+    /// https://docs.rs/num-traits/latest/num_traits/identities/trait.Zero.html#tymethod.zero
     ///
     /// ```rust
     /// # use counter::Counter;
@@ -503,7 +529,7 @@ where
 {
     type Output = Counter<T, N>;
 
-    /// Intersection
+    /// Returns the intersection of `self` and `rhs` as a new `Counter`.
     ///
     /// `out = c & d;` -> `out[x] == min(c[x], d[x])`
     ///
@@ -539,7 +565,7 @@ where
 {
     type Output = Counter<T, N>;
 
-    /// Union
+    /// Returns the union of `self` and `rhs` as a new `Counter`.
     ///
     /// `out = c | d;` -> `out[x] == max(c[x], d[x])`
     ///
@@ -619,7 +645,7 @@ where
     type Item = (T, N);
     type IntoIter = std::collections::hash_map::IntoIter<T, N>;
 
-    /// Consumes the Counter to produce an iterator that owns the values it returns
+    /// Consumes the `Counter` to produce an iterator that owns the values it returns.
     ///
     /// # Examples
     /// ```rust
@@ -651,7 +677,7 @@ where
     type Item = (&'a T, &'a mut N);
     type IntoIter = std::collections::hash_map::IterMut<'a, T, N>;
 
-    /// Creates an iterator that provides mutable references to the counts, but keeps the key immutable
+    /// Creates an iterator that provides mutable references to the counts, but keeps the keys immutable.
     ///
     /// # Examples
     /// ```rust
@@ -682,9 +708,12 @@ where
 {
     type Output = N;
 
-    /// Index in immutable contexts
+    /// Index in immutable contexts.
     ///
-    /// Returns a reference to a `zero` value for missing keys.
+    /// Returns a reference to a [`zero`] value for missing keys.
+    ///
+    /// [`zero`]:
+    /// https://docs.rs/num-traits/latest/num_traits/identities/trait.Zero.html#tymethod.zero
     ///
     /// ```
     /// # use counter::Counter;
@@ -695,7 +724,12 @@ where
     /// assert_eq!(counter[&'d'], 0);
     /// ```
     ///
-    /// Note that the `zero` is a struct filed but not one of the values of the inner `HashMap`. This method does not modify any existing value.
+    /// Note that the [`zero`] is a struct field but not one of the values of the inner
+    /// [`HashMap`].  This method does not modify any existing value.
+    ///
+    /// [`zero`]:
+    /// https://docs.rs/num-traits/latest/num_traits/identities/trait.Zero.html#tymethod.zero
+    /// [`HashMap`]: https://doc.rust-lang.org/stable/std/collections/struct.HashMap.html
     ///
     /// ```
     /// # use counter::Counter;
@@ -714,9 +748,13 @@ where
     Q: Hash + Eq + ToOwned<Owned = T>,
     N: Zero,
 {
-    /// Index in mutable contexts
+    /// Index in mutable contexts.
     ///
-    /// If the given key is not present, creates a new entry and initializes it with a `zero` value.
+    /// If the given key is not present, creates a new entry and initializes it with a [`zero`]
+    /// value.
+    ///
+    /// [`zero`]:
+    /// https://docs.rs/num-traits/latest/num_traits/identities/trait.Zero.html#tymethod.zero
     ///
     /// ```
     /// # use counter::Counter;
@@ -727,7 +765,12 @@ where
     /// assert_eq!(counter[&'d'], 1);
     /// ```
     ///
-    /// Unlike `Index::index`, The returned mutable reference to the `zero` is actually one of the values of the inner `HashMap`.
+    /// Unlike `Index::index`, the returned mutable reference to the [`zero`] is actually one of the
+    /// values of the inner [`HashMap`].
+    ///
+    /// [`zero`]:
+    /// https://docs.rs/num-traits/latest/num_traits/identities/trait.Zero.html#tymethod.zero
+    /// [`HashMap`]: https://doc.rust-lang.org/stable/std/collections/struct.HashMap.html
     ///
     /// ```
     /// # use counter::Counter;
@@ -747,7 +790,7 @@ where
     T: Hash + Eq,
     N: AddAssign + Zero + One,
 {
-    /// Directly add the counts of the elements of `I` to `self`
+    /// Directly add the counts of the elements of `I` to `self`.
     ///
     /// ```rust
     /// # use counter::Counter;
@@ -771,8 +814,8 @@ where
     N: AddAssign + Zero + One,
 {
     type Output = Self;
-    /// Consume self producing a Counter like self updated with the counts of
-    /// the elements of I.
+    /// Consume `self` producing a `Counter` like `self` updated with the counts of
+    /// the elements of `I`.
     ///
     /// ```rust
     /// # use counter::Counter;
@@ -797,7 +840,10 @@ where
     N: PartialOrd + SubAssign + Zero + One,
 {
     /// Directly subtract the counts of the elements of `I` from `self`,
-    /// keeping only items with a value greater than N::zero().
+    /// keeping only items with a value greater than [`N::zero()`].
+    ///
+    /// [`N::zero()`]:
+    /// https://docs.rs/num-traits/latest/num_traits/identities/trait.Zero.html#tymethod.zero
     ///
     /// ```rust
     /// # use counter::Counter;
@@ -820,8 +866,8 @@ where
     N: PartialOrd + SubAssign + Zero + One,
 {
     type Output = Self;
-    /// Consume self producing a Counter like self with the counts of the
-    /// elements of I subtracted, keeping only positive values.
+    /// Consume `self` producing a `Counter` like `self` with the counts of the
+    /// elements of `I` subtracted, keeping only positive values.
     ///
     /// ```rust
     /// # use counter::Counter;
@@ -843,8 +889,11 @@ where
     T: Hash + Eq,
     N: AddAssign + Zero + One,
 {
-    /// Produce a Counter from an iterator of items. This is called automatically
-    /// by `iter.collect()`.
+    /// Produce a `Counter` from an iterator of items. This is called automatically
+    /// by [`Iterator::collect()`].
+    ///
+    /// [`Iterator::collect()`]:
+    /// https://doc.rust-lang.org/stable/std/iter/trait.Iterator.html#method.collect
     ///
     /// ```rust
     /// # use counter::Counter;
@@ -864,7 +913,7 @@ where
     T: Hash + Eq,
     N: AddAssign + Zero,
 {
-    /// `from_iter` creates a counter from `(item, count)` tuples.
+    /// Creates a counter from `(item, count)` tuples.
     ///
     /// The counts of duplicate items are summed.
     /// ```rust
@@ -891,7 +940,7 @@ where
     T: Hash + Eq,
     N: AddAssign + Zero + One,
 {
-    /// Extend a Counter with an iterator of items.
+    /// Extend a `Counter` with an iterator of items.
     ///
     /// ```rust
     /// # use counter::Counter;
@@ -938,7 +987,7 @@ where
 {
     /// Extend a counter with `(item, count)` tuples.
     ///
-    /// You can extend a Counter with another Counter:
+    /// You can extend a `Counter` with another `Counter`:
     /// ```rust
     /// # use counter::Counter;
     /// # use std::collections::HashMap;


### PR DESCRIPTION
Here are a few cleanups to the documentation, mostly the formatting not the substance:

- Update link to the Python documentation to the latest 3.x version instead of 3.5.
- Add missing markdown inline code formatting and links to other documentation as appropriate.
- Fix typos, add missing periods to the ends of sentences.
- Regenerate `REAMDME.md` with [cargo-readme](https://github.com/livioribeiro/cargo-readme).

Note that the documentation is inconsistent in how it refers to its primary type, sometimes using `Counter` and sometimes "counter".  That's probably fine, the standard library often does the same thing (`Vec` and "vector", etc.).  This PR does not attempt to standardize to one or the other way of refering to it.  However, where the documentation used "Counter" with a captial C but no inline code formatting, we have added the markdown formatting.  If you would like to decide on a standard way to refer to counters and make the use consistent throughout the documentation, I would be happy to ammend this PR with any necessary changes.
