### PR TITLE
Add method to return the `k` most common items and speed up `most_common_*()` methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ num-traits = "0.2"
 
 [dev-dependencies]
 maplit = "1.0"
+rand = "0.8.5"

--- a/README.md
+++ b/README.md
@@ -64,6 +64,20 @@ let expected = vec![('c', 3), ('b', 2), ('d', 2), ('a', 1), ('e', 1)];
 assert!(by_common == expected);
 ```
 
+[`k_most_common_ordered()`] takes an argument `k` of type `usize` and returns the top `k` most
+common items.  This is functionally equivalent to calling `most_common_ordered()` and then
+truncating the result to length `k`.  However, if `k` is smaller than the length of the counter
+then `k_most_common_ordered()` can be more efficient, often much more so.
+
+```rust
+let by_common = "eaddbbccc".chars().collect::<Counter<_>>().k_most_common_ordered(2);
+let expected = vec![('c', 3), ('b', 2)];
+assert!(by_common == expected);
+```
+
+[`k_most_common_ordered()`]: Counter::k_most_common_ordered
+[`most_common_ordered()`]: Counter::most_common_ordered
+
 ### Get the most common items using your own ordering
 
 For example, here we break ties reverse alphabetically.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1110,6 +1110,7 @@ where
 mod tests {
     use super::*;
     use maplit::hashmap;
+    use rand::Rng;
     use std::collections::HashMap;
 
     #[test]
@@ -1289,6 +1290,31 @@ mod tests {
         for k in 0..=counter.len() {
             let topk = counter.k_most_common_ordered(k);
             assert_eq!(&topk, &all[..k]);
+        }
+    }
+
+    /// This test is fundamentally the same as `test_k_most_common_ordered`, but it operates on
+    /// a wider variety of data. In particular, it tests both longer, narrower, and wider
+    /// distributions of data than the other test does.
+    #[test]
+    fn test_k_most_common_ordered_heavy() {
+        let mut rng = rand::thread_rng();
+
+        for container_size in [5, 10, 25, 100, 256] {
+            for max_value_factor in [0.25, 0.5, 1.0, 1.25, 2.0, 10.0, 100.0] {
+                let max_value = ((container_size as f64) * max_value_factor) as u32;
+                let mut values = vec![0; container_size];
+                for value in values.iter_mut() {
+                    *value = rng.gen_range(0..=max_value);
+                }
+
+                let counter: Counter<_> = values.into_iter().collect();
+                let all = counter.most_common_ordered();
+                for k in 0..=counter.len() {
+                    let topk = counter.k_most_common_ordered(k);
+                    assert_eq!(&topk, &all[..k]);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

This PR proposes the following changes to improve the flexibility and efficiency of `Counter`'s API for obtaining the most common items in the counter.

1. Add dedicated method `k_most_common_ordered()` to return a vector of the *k* most common items.
2. Switch from a stable to an unstable sorting algorithm in `most_common_tiebreaker()`.

## Motivation

At present `Counter` offers no way for a user to specifically ask for the *k* most common items, where *k* may be less than the length of the counter *n*.  While it is easy enough to do something like the following, such code would be quite inefficient if *k* is small compared to *n*:

```rust
let mut most_common = counter.most_common();
most_common.truncate(k);
```

The above code sorts the entire list of *n* items, which has complexity *O*(*n* * log *n*), when all we need to do is to select the top *k* most common items and then sort just those *k* items.  Selecting just the top *k* items can be accomplished efficiently by using a binary heap.  The resulting algorithm can be much more efficient than sorting all *n* items.  For a fixed value of *k*, this algorithm scales with increasing *n* as *n* + *O*(log *n*), instead of *O*(*n* * log *n*) when sorting all *n* items.  For the extreme case of *k* = 1, this requires only *n* \- 1 comparisons.  In the limit as *k* approaches *n*, this algorithm approaches a heapsort of the *n* items.

This is precisely what Python's implementation in [`collections.Counter.most_common()`](https://github.com/python/cpython/blob/a10cf2f6b3766f9dbbe54bdaacfb3f2ca406ea3d/Lib/collections/__init__.py#L608) does, calling [`heapq.nlargest()`](https://github.com/python/cpython/blob/a10cf2f6b3766f9dbbe54bdaacfb3f2ca406ea3d/Lib/heapq.py#L523).  For a more detailed analysis of the complexity of the algorithm, see [these notes](https://github.com/python/cpython/blob/a10cf2f6b3766f9dbbe54bdaacfb3f2ca406ea3d/Lib/heapq.py#L397-L461) in the Python source code.  The implementation here is fairly similar.

For `counter-rs` there is an additional advantage to providing a dedicated API for the *k* most common items.  Since the existing `most_common_*()` functions return owned values of the key type `T` and therefore have to clone the keys, a method for obtaining only the top *k* most common items could get away with cloning only *k* keys instead of all *n*.

It would be nice to add a method which implements this more efficient algorithm when only the top *k* most common items are desired.  A check of some [dependents of `counter-rs`](https://crates.io/crates/counter/reverse_dependencies) shows 2 of the 9 listed crates using `Counter::most_common()` for the purpose of finding the single most common item: see examples [here](https://github.com/varlociraptor/varlociraptor/blob/0d2eef7117792d715379d03b142257fb20b5ee2f/src/variants/evidence/observations/read_observation.rs#L448-L478) and [here](https://github.com/paulkernfeld/hmmm/blob/0c1ced7bf9bcc6551e3857962713da20fe942670/src/lib.rs#L1107-L1120).

Finally, `most_common_tiebreaker()` uses the stable `slice::sort_by()` algorithm (based on timsort) instead of `slice::sort_unstable_by()` (based on quicksort).  There is a definite performance improvement to be had by switching to the unstable quicksort algorithm.  This is [recommended in the documentation](https://doc.rust-lang.org/stable/std/primitive.slice.html#method.sort_by) in cases where the stability guarantee is not needed.  In the case of `Counter`, there is no reason to preserve the relative pre-sort order of items which compare as equal, since this order is already unspecified due to the hashing function.

## Benchmarks

I made some simple benchmarks to compare the times of `most_common_ordered()` and `k_most_common_ordered()` for various values of `k`, as well as to compare `slice::sort_by()` and `slice::sort_unstable_by()` in `most_common_ordered()` with counters of various lengths.  

Some of the benchmarks use counters where the counts were just `0..n`, so all of the counts are distinct and there are no ties.  These cases used two different key types, `usize` and `String`, so that we test both with a `Copy` type and a type where there is a nontrivial cost to cloning the keys.  The strings keys all had length 16.

Another set of benchmarks used a more realistic example by making counts of the frequencies of all the words appearing in [The Complete Works of William Shakespeare](https://www.gutenberg.org/ebooks/100.txt.utf-8).  (Here "words" are continguous ASCII alphabetic characters seperated by non-alphabetic characters.)  There are a total of 988,852 words, of which 25,469 are distinct.  There are of course many ties, that is words having the same counts, and ties are much more common among low frequency words than among high frequency words.  This situation is another advantage for `k_most_common_ordered()`: it has to break ties less often than does `most_common_ordered()` and tiebreaking is a more expensive comparision operation.  This set of benchmarks used counters with both borrowed (`&str`) and owned (`String`) keys.

All times are in units of microseconds.  All counts are of type `usize`.

### stable vs unstable sorting

Comparison of `Counter::<usize>::most_common_ordered()` when using `slice::sort_by()` and `slice::sort_unstable_by()` for counters of size `n`:

|    `n`    |   stable    |   unstable    |   % change    |
|----------:|-------------:|--------------:|--------------:|
|    100    |    2.8533    |    2.1542     |   -25.070     |
|   1000    |   42.303     |   25.604      |   -40.206     |
|  10000    |  559.32      |  294.52       |   -48.002     |
| 100000    | 6668.8       | 3426.1        |   -48.638     |

Similar tests except the keys are of type `String` and all keys have length 16:

|    `n`    |   stable    |   unstable    |   % change    |
|----------:|-------------:|--------------:|--------------:|
|    100    |    5.1853    |    4.8483     |   -11.408     |
|   1000    |   64.252     |   58.435      |   -11.118     |
|  10000    |  745.59      |  657.32       |   -16.144     |
| 100000    | 9100.4       | 6965.4        |   -23.460     |

Comparison using the counters containing the frequencies of words in Shakespeare's complete works:

|   `T`     |   stable  |  unstable |   % change    |
|:----------|----------:|----------:|--------------:|
|   `&str`  |   4889.7  |   2814.5  |   -42.393     |
|   `String`|   5489.4  |   4083.6  |   -25.610     |

### *k* most common items

These benchmarks use counters of size 10000 with `usize` and `String` keys.  We compare  the times of `k_most_common_ordered()` for various values of `k` against those of `most_common_ordered()` when using both the stable and unstable sorts.

| `T`     |        1  |       10  |      100  |     1000  |     5000  |   stable | unstable |
|:--------|----------:|----------:|----------:|----------:|----------:|---------:|---------:|
| `usize` |   31.341  |   32.882  |   45.239  |   136.90  |   366.11  |   559.32 | 294.52 |
| `String`|   20.259  |   24.331  |   37.139  |   153.75  |   473.45  |   745.59 | 657.32 |

Similar comparisons using counters of the frequencies of words in Shakespeare's complete works (25469 keys):

| `T`     |        1  |       10  |      100  |     1000  |    10000  |   stable  | unstable |
|:--------|----------:|----------:|----------:|----------:|----------:|---------:|---------:|
| `&str`  |   44.445  |   45.209  |   64.230  |   436.42  |   3929.9  |  4889.7  | 2814.5 |
| `String`|   44.347  |   45.695  |   66.491  |   475.45  |   4146.6  |  5489.4  | 4083.6 |
