### PR TITLE
Add bench

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ num-traits = "0.2"
 [dev-dependencies]
 maplit = "1.0"
 rand = "0.8.5"
-
+criterion = { version = "0.5", features = ["html_reports"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,7 @@ num-traits = "0.2"
 maplit = "1.0"
 rand = "0.8.5"
 criterion = { version = "0.5", features = ["html_reports"] }
+
+[[bench]]
+name = "counter_bench"
+harness = false

--- a/benches/counter_bench.rs
+++ b/benches/counter_bench.rs
@@ -1,0 +1,76 @@
+use counter::Counter;
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+#[allow(unused)]
+#[inline]
+fn just_count_iterable(black_box: usize) {
+    let char_counts = "barefoot".chars().collect::<Counter<_>>();
+    let counts_counts = char_counts.values().collect::<Counter<_>>();
+}
+
+#[allow(unused)]
+#[inline]
+fn update_a_count(black_box: usize) {
+    let mut counts = "aaa".chars().collect::<Counter<_>>();
+    counts[&'a'] += 1;
+    counts[&'b'] += 1;
+}
+
+#[allow(unused)]
+#[inline]
+fn update_a_count_2(black_box: usize) {
+    let mut counts = "able babble table babble rabble table able fable scrabble"
+        .split_whitespace()
+        .collect::<Counter<_>>();
+    counts += "cain and abel fable table cable".split_whitespace();
+    let other_counts = "scrabble cabbie fable babble"
+        .split_whitespace()
+        .collect::<Counter<_>>();
+    let difference = counts - other_counts;
+}
+
+#[allow(unused)]
+#[inline]
+fn get_most_common_items(black_box: usize) {
+    let by_common = "eaddbbccc"
+        .chars()
+        .collect::<Counter<_>>()
+        .most_common_ordered();
+    let expected = vec![('c', 3), ('b', 2), ('d', 2), ('a', 1), ('e', 1)];
+    assert!(by_common == expected);
+}
+
+#[allow(unused)]
+#[inline]
+fn get_k_most_common(black_box: usize) {
+    let by_common = "eaddbbccc"
+        .chars()
+        .collect::<Counter<_>>()
+        .k_most_common_ordered(2);
+    let expected = vec![('c', 3), ('b', 2)];
+    assert!(by_common == expected);
+}
+
+#[allow(unused)]
+#[inline]
+fn most_common_tiebreaker_benched(black_box: usize) {
+    let counter = "eaddbbccc".chars().collect::<Counter<_>>();
+    let by_common = counter.most_common_tiebreaker(|&a, &b| b.cmp(&a));
+    let expected = vec![('c', 3), ('d', 2), ('b', 2), ('e', 1), ('a', 1)];
+    assert_eq!(by_common, expected);
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("just count an iterable", |b| {
+        b.iter(|| get_most_common_items(black_box(20)))
+    });
+    c.bench_function("get_k_most_common", |b| {
+        b.iter(|| get_k_most_common(black_box(20)))
+    });
+    c.bench_function("most_common_tiebreaker_benched", |b| {
+        b.iter(|| most_common_tiebreaker_benched(black_box(20)))
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);


### PR DESCRIPTION
I've added a rudimentary bench with all the necessary pieces including `Cargo.toml` changes.

I've chosen a few that I felt that **could** be rayonified, but reading the code with a fresh set of eyes I can see that it would be a challenging task.

Anyway i basically copy pasted a lot from the docstrings and it shows.
From here I think we can choose or build benches that seem to be more relevant.

After the functions to bench are chosen we can modify them further.
For instance, removing assertions, making functions take multiple different kinds of input lengths (K, M, G scale comes to mind) etc.

I'd like to reemphasize that I do not see this PR to be pulled as is. This is merely the skeleton to be built upon.