### PR TITLE
With capacity

### DIFF
--- a/src/impls/create.rs
+++ b/src/impls/create.rs
@@ -17,6 +17,13 @@ where
             zero: N::zero(),
         }
     }
+    #[must_use]
+    pub fn with_capacity(capacity: usize) -> Self {
+        Counter {
+            map: HashMap::with_capacity(capacity),
+            zero: N::zero(),
+        }
+    }
 }
 
 impl<T, N> Default for Counter<T, N>

--- a/src/impls/create.rs
+++ b/src/impls/create.rs
@@ -17,7 +17,12 @@ where
             zero: N::zero(),
         }
     }
-    #[must_use]
+
+    /// Create a new, empty `Counter` with the specified capacity.
+    ///
+    /// Note that `capacity` in this case indicates how many distinct items may be counted without reallocation.
+    /// It is not related to the total number of items which may be counted.
+    /// For example, `"aaa"` requires a capacity of 1. `"abc"` requires a capacity of 3.
     pub fn with_capacity(capacity: usize) -> Self {
         Counter {
             map: HashMap::with_capacity(capacity),

--- a/src/impls/from_iterator.rs
+++ b/src/impls/from_iterator.rs
@@ -19,17 +19,6 @@ where
     {
         Self::from_iter(iterable)
     }
-
-    /// Create a new `Counter` initialized with the given iterable.
-    /// Allocate with iterator size hints, defaulting to the lowerbound
-    pub fn init_with_capacity<I>(iterable: I, capacity: usize) -> Self
-    where
-        I: IntoIterator<Item = T>,
-    {
-        let mut counter: Counter<T, N> = Counter::with_capacity(capacity);
-        counter.update(iterable);
-        counter
-    }
 }
 
 impl<T, N> iter::FromIterator<T> for Counter<T, N>

--- a/src/impls/from_iterator.rs
+++ b/src/impls/from_iterator.rs
@@ -20,6 +20,19 @@ where
         counter.update(iterable);
         counter
     }
+    pub fn init_with_capacity<I>(iterable: I) -> Self
+    where
+        I: IntoIterator<Item = T>,
+    {
+        let iterator = iterable.into_iter();
+        let (lower_bound, upper_bound) = iterator.size_hint();
+
+        let capacity = upper_bound.unwrap_or(lower_bound);
+        let mut counter: Counter<T, N> = Counter::with_capacity(capacity);
+
+        counter.update(iterator);
+        counter
+    }
 }
 
 impl<T, N> iter::FromIterator<T> for Counter<T, N>

--- a/src/impls/from_iterator.rs
+++ b/src/impls/from_iterator.rs
@@ -22,17 +22,12 @@ where
 
     /// Create a new `Counter` initialized with the given iterable.
     /// Allocate with iterator size hints, defaulting to the lowerbound
-    pub fn init_with_capacity<I>(iterable: I) -> Self
+    pub fn init_with_capacity<I>(iterable: I, capacity: usize) -> Self
     where
         I: IntoIterator<Item = T>,
     {
-        let iterator = iterable.into_iter();
-        let (lower_bound, upper_bound) = iterator.size_hint();
-
-        let capacity = upper_bound.unwrap_or(lower_bound);
         let mut counter: Counter<T, N> = Counter::with_capacity(capacity);
-
-        counter.update(iterator);
+        counter.update(iterable);
         counter
     }
 }

--- a/src/impls/from_iterator.rs
+++ b/src/impls/from_iterator.rs
@@ -20,6 +20,9 @@ where
         counter.update(iterable);
         counter
     }
+
+    /// Create a new `Counter` initialized with the given iterable.
+    /// Allocate with iterator size hints, defaulting to the lowerbound
     pub fn init_with_capacity<I>(iterable: I) -> Self
     where
         I: IntoIterator<Item = T>,

--- a/src/unit_tests.rs
+++ b/src/unit_tests.rs
@@ -15,14 +15,8 @@ fn test_creation() {
 
 #[test]
 fn test_creation_with_capacity() {
-    let initializer = &[1];
-    let counter = Counter::init_with_capacity(initializer,1);
-
-    let mut expected = HashMap::with_capacity(1);
-    static ONE: usize = 1;
-    expected.insert(&ONE, 1);
-    assert!(counter.map == expected);
-    assert!(counter.map.capacity() == expected.capacity());
+    let counter = Counter::with_capacity(1);
+    assert_eq!(counter.map.capacity(), 1);
 }
 
 #[test]

--- a/src/unit_tests.rs
+++ b/src/unit_tests.rs
@@ -15,8 +15,8 @@ fn test_creation() {
 
 #[test]
 fn test_creation_with_capacity() {
-    let counter = Counter::with_capacity(1);
-    assert_eq!(counter.map.capacity(), 1);
+    let counter: Counter<usize,usize> = Counter::with_capacity(3);
+    assert_eq!(counter.map.capacity(), 3);
 }
 
 #[test]

--- a/src/unit_tests.rs
+++ b/src/unit_tests.rs
@@ -17,7 +17,7 @@ fn test_creation() {
 #[test]
 fn test_creation_with_capacity() {
     let initializer = &[1];
-    let counter = Counter::init_with_capacity(initializer);
+    let counter = Counter::init_with_capacity(initializer,1);
 
     let mut expected = HashMap::with_capacity(1);
     static ONE: usize = 1;
@@ -25,7 +25,6 @@ fn test_creation_with_capacity() {
     assert!(counter.map == expected);
     assert!(counter.map.capacity() == expected.capacity());
 }
-
 
 #[test]
 fn test_update() {

--- a/src/unit_tests.rs
+++ b/src/unit_tests.rs
@@ -15,7 +15,7 @@ fn test_creation() {
 
 #[test]
 fn test_creation_with_capacity() {
-    let counter: Counter<usize,usize> = Counter::with_capacity(3);
+    let counter: Counter<usize, usize> = Counter::with_capacity(3);
     assert_eq!(counter.map.capacity(), 3);
 }
 

--- a/src/unit_tests.rs
+++ b/src/unit_tests.rs
@@ -13,6 +13,20 @@ fn test_creation() {
     expected.insert(&ONE, 1);
     assert!(counter.map == expected);
 }
+
+#[test]
+fn test_creation_with_capacity() {
+    let initializer = &[1];
+    let counter = Counter::init_with_capacity(initializer);
+
+    let mut expected = HashMap::with_capacity(1);
+    static ONE: usize = 1;
+    expected.insert(&ONE, 1);
+    assert!(counter.map == expected);
+    assert!(counter.map.capacity() == expected.capacity());
+}
+
+
 #[test]
 fn test_update() {
     let mut counter = Counter::init("abbccc".chars());


### PR DESCRIPTION
this implements both
`Counter::with_capacity` and `Counter::init_with_capacity` with the bare minimum tests

i tested internally but atleast the tests pass even if i replace `init` with `init_with_capacity` but I didn't want to make drastic changes at this point.