### PR TITLE
deprecate `init` method

### DIFF
--- a/src/impls/from_iterator.rs
+++ b/src/impls/from_iterator.rs
@@ -17,9 +17,7 @@ where
     where
         I: IntoIterator<Item = T>,
     {
-        let mut counter = Counter::new();
-        counter.update(iterable);
-        counter
+        Self::from_iter(iterable)
     }
 }
 
@@ -42,8 +40,10 @@ where
     /// assert_eq!(counter.into_map(), expect);
     /// ```
     ///
-    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
-        Counter::<T, N>::init(iter)
+    fn from_iter<I: IntoIterator<Item = T>>(iterable: I) -> Self {
+        let mut counter = Counter::new();
+        counter.update(iterable);
+        counter
     }
 }
 

--- a/src/impls/from_iterator.rs
+++ b/src/impls/from_iterator.rs
@@ -12,6 +12,7 @@ where
     N: AddAssign + Zero + One,
 {
     /// Create a new `Counter` initialized with the given iterable.
+    #[deprecated = "prefer the `FromIterator`/`collect` interface"]
     pub fn init<I>(iterable: I) -> Self
     where
         I: IntoIterator<Item = T>,


### PR DESCRIPTION
Using `FromIterator` or `collect` is simply more idiomatic than `init`, so users should prefer those methods.