### PR TITLE
Clippy fixes

### DIFF
--- a/src/impls/create.rs
+++ b/src/impls/create.rs
@@ -38,7 +38,7 @@ where
 {
     fn default() -> Self {
         Self {
-            map: Default::default(),
+            map: HashMap::default(),
             zero: Default::default(),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -274,6 +274,8 @@
 //! assert!(counter.into_map() == expected);
 //! ```
 
+
+#![allow(clippy::must_use_candidate)]
 mod impls;
 
 use num_traits::{One, Zero};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -274,7 +274,6 @@
 //! assert!(counter.into_map() == expected);
 //! ```
 
-
 #![allow(clippy::must_use_candidate)]
 mod impls;
 
@@ -499,6 +498,9 @@ where
     /// be worth experimenting to see which of the two methods is faster.
     ///
     /// [`most_common_ordered`]: Counter::most_common_ordered
+    /// 
+    /// # Panics
+    /// Panics if heap is empty
     pub fn k_most_common_ordered(&self, k: usize) -> Vec<(T, N)> {
         use std::cmp::Reverse;
 


### PR DESCRIPTION
This PR ensures that even `cargo clippy -- -Wclippy::pedantic` yields no warnings.

One issue : I'm not sure if `k_most_common_ordered` can actually panic?
It seems like logically `heap` won't be empty. 
If it can, maybe documentation could be better so it is understood in relation to outputs.
If not, maybe we can change it to unwrap and either document that it doesn't panic or suppress the lint