### PR TITLE
Fromiterator withcapacity

### DIFF
--- a/src/impls/from_iterator.rs
+++ b/src/impls/from_iterator.rs
@@ -42,8 +42,10 @@ where
     ///
     fn from_iter<I: IntoIterator<Item = T>>(iterable: I) -> Self {
         let iterator = iterable.into_iter();
+
         let (lowerbound, upperbound) = iterator.size_hint();
         let capacity = upperbound.unwrap_or(lowerbound);
+
         let mut counter = Counter::with_capacity(capacity);
         counter.update(iterator);
         counter

--- a/src/impls/from_iterator.rs
+++ b/src/impls/from_iterator.rs
@@ -75,11 +75,13 @@ where
         let (lowerbound, upperbound) = iterator.size_hint();
         let capacity = upperbound.unwrap_or(lowerbound);
 
-        let mut cnt = Counter::with_capacity(capacity);
-        for (item, item_count) in iterator {
-            let entry = cnt.map.entry(item).or_insert_with(N::zero);
-            *entry += item_count;
-        }
-        cnt
+        iterator.fold(
+            Counter::with_capacity(capacity),
+            |mut cnt, (item, item_count)| {
+                let entry = cnt.map.entry(item).or_insert_with(N::zero);
+                *entry += item_count;
+                cnt
+            },
+        )
     }
 }

--- a/src/impls/from_iterator.rs
+++ b/src/impls/from_iterator.rs
@@ -41,8 +41,11 @@ where
     /// ```
     ///
     fn from_iter<I: IntoIterator<Item = T>>(iterable: I) -> Self {
-        let mut counter = Counter::new();
-        counter.update(iterable);
+        let iterator = iterable.into_iter();
+        let (lowerbound, upperbound) = iterator.size_hint();
+        let capacity = upperbound.unwrap_or(lowerbound);
+        let mut counter = Counter::with_capacity(capacity);
+        counter.update(iterator);
         counter
     }
 }

--- a/src/impls/from_iterator.rs
+++ b/src/impls/from_iterator.rs
@@ -70,8 +70,13 @@ where
     /// assert_eq!(counter.into_map(), expect);
     /// ```
     fn from_iter<I: IntoIterator<Item = (T, N)>>(iter: I) -> Self {
-        let mut cnt = Counter::new();
-        for (item, item_count) in iter {
+        let iterator = iter.into_iter();
+
+        let (lowerbound, upperbound) = iterator.size_hint();
+        let capacity = upperbound.unwrap_or(lowerbound);
+
+        let mut cnt = Counter::with_capacity(capacity);
+        for (item, item_count) in iterator {
             let entry = cnt.map.entry(item).or_insert_with(N::zero);
             *entry += item_count;
         }


### PR DESCRIPTION
This implements `iterator.size_hint()` based bounds to call `with_capacity`.

The last commit 5f5aa09 uses the new capacity based implementation to change the `for` based implementation to a `fold()` based one.

Arguably it is more idiomatic, but it is not necessarily more concise or clear compared to the for based version. However, as an objective benefit beyond the subjective, it can make a potential rayon implementation with `into_par_iter` easier.

If the 5f5aa09 seem out of scope or irrelevant to `with_capacity`, it can easily be reverted and prepared as part of a new PR.