### PR TITLE
replace `for` with `.fold()`

### DIFF
--- a/src/impls/from_iterator.rs
+++ b/src/impls/from_iterator.rs
@@ -65,11 +65,11 @@ where
     /// assert_eq!(counter.into_map(), expect);
     /// ```
     fn from_iter<I: IntoIterator<Item = (T, N)>>(iter: I) -> Self {
-        let mut cnt = Counter::new();
-        for (item, item_count) in iter {
-            let entry = cnt.map.entry(item).or_insert_with(N::zero);
-            *entry += item_count;
-        }
-        cnt
+        iter.into_iter()
+            .fold(Counter::new(), |mut cnt, (item, item_count)| {
+                let entry = cnt.map.entry(item).or_insert_with(N::zero);
+                *entry += item_count;
+                cnt
+            })
     }
 }


### PR DESCRIPTION
This was kinda hacked into #44 as an after thought, but since it seems that might not be a good idea at this point, I extracted the `fold()` changes.

Whether this is more idiomatic code is subjective. Since subjective aspects would come down to the preference of the maintainer, I won't go too much into it. I will go into objective parts.

* `for` isn't strictly necessary since each closure, except for the `Counter` access has no other side effects
* this construction would make it easier for functional extensions, such as `rayon::into_par_iter()` (Although certain concurrency or atomicity related changes would need to be made for this)
