### PR TITLE
Add support for custom hashers

### DIFF
--- a/src/impls/add_iterable.rs
+++ b/src/impls/add_iterable.rs
@@ -2,14 +2,15 @@ use crate::Counter;
 
 use num_traits::{One, Zero};
 
-use std::hash::Hash;
+use std::hash::{BuildHasher, Hash};
 use std::ops::{Add, AddAssign};
 
-impl<I, T, N> Add<I> for Counter<T, N>
+impl<I, T, N, S> Add<I> for Counter<T, N, S>
 where
     I: IntoIterator<Item = T>,
     T: Hash + Eq,
     N: AddAssign + Zero + One,
+    S: BuildHasher,
 {
     type Output = Self;
     /// Consume `self` producing a `Counter` like `self` updated with the counts of
@@ -31,11 +32,12 @@ where
     }
 }
 
-impl<I, T, N> AddAssign<I> for Counter<T, N>
+impl<I, T, N, S> AddAssign<I> for Counter<T, N, S>
 where
     I: IntoIterator<Item = T>,
     T: Hash + Eq,
     N: AddAssign + Zero + One,
+    S: BuildHasher,
 {
     /// Directly add the counts of the elements of `I` to `self`.
     ///

--- a/src/impls/add_self.rs
+++ b/src/impls/add_self.rs
@@ -2,15 +2,16 @@ use crate::Counter;
 
 use num_traits::Zero;
 
-use std::hash::Hash;
+use std::hash::{BuildHasher, Hash};
 use std::ops::{Add, AddAssign};
 
-impl<T, N> Add for Counter<T, N>
+impl<T, N, S> Add for Counter<T, N, S>
 where
     T: Clone + Hash + Eq,
     N: AddAssign + Zero,
+    S: BuildHasher,
 {
-    type Output = Counter<T, N>;
+    type Output = Counter<T, N, S>;
 
     /// Add two counters together.
     ///
@@ -27,16 +28,17 @@ where
     /// let expect = [('a', 4), ('b', 3)].iter().cloned().collect::<HashMap<_, _>>();
     /// assert_eq!(e.into_map(), expect);
     /// ```
-    fn add(mut self, rhs: Counter<T, N>) -> Self::Output {
+    fn add(mut self, rhs: Counter<T, N, S>) -> Self::Output {
         self += rhs;
         self
     }
 }
 
-impl<T, N> AddAssign for Counter<T, N>
+impl<T, N, S> AddAssign for Counter<T, N, S>
 where
     T: Hash + Eq,
     N: Zero + AddAssign,
+    S: BuildHasher,
 {
     /// Add another counter to this counter.
     ///

--- a/src/impls/create.rs
+++ b/src/impls/create.rs
@@ -5,15 +5,16 @@ use num_traits::Zero;
 use std::collections::HashMap;
 use std::hash::Hash;
 
-impl<T, N> Counter<T, N>
+impl<T, N, S> Counter<T, N, S>
 where
     T: Hash + Eq,
     N: Zero,
+    S: Default,
 {
     /// Create a new, empty `Counter`
     pub fn new() -> Self {
         Counter {
-            map: HashMap::new(),
+            map: HashMap::<T, N, S>::default(),
             zero: N::zero(),
         }
     }
@@ -25,15 +26,16 @@ where
     /// For example, `"aaa"` requires a capacity of 1. `"abc"` requires a capacity of 3.
     pub fn with_capacity(capacity: usize) -> Self {
         Counter {
-            map: HashMap::with_capacity(capacity),
+            map: HashMap::with_capacity_and_hasher(capacity, S::default()),
             zero: N::zero(),
         }
     }
 }
 
-impl<T, N> Default for Counter<T, N>
+impl<T, N, S> Default for Counter<T, N, S>
 where
     N: Default,
+    S: Default,
 {
     fn default() -> Self {
         Self {

--- a/src/impls/deref.rs
+++ b/src/impls/deref.rs
@@ -3,15 +3,15 @@ use crate::Counter;
 use std::collections::HashMap;
 use std::ops::{Deref, DerefMut};
 
-impl<T, N> Deref for Counter<T, N> {
-    type Target = HashMap<T, N>;
-    fn deref(&self) -> &HashMap<T, N> {
+impl<T, N, S> Deref for Counter<T, N, S> {
+    type Target = HashMap<T, N, S>;
+    fn deref(&self) -> &HashMap<T, N, S> {
         &self.map
     }
 }
 
-impl<T, N> DerefMut for Counter<T, N> {
-    fn deref_mut(&mut self) -> &mut HashMap<T, N> {
+impl<T, N, S> DerefMut for Counter<T, N, S> {
+    fn deref_mut(&mut self) -> &mut HashMap<T, N, S> {
         &mut self.map
     }
 }

--- a/src/impls/extend.rs
+++ b/src/impls/extend.rs
@@ -2,13 +2,14 @@ use crate::Counter;
 
 use num_traits::{One, Zero};
 
-use std::hash::Hash;
+use std::hash::{BuildHasher, Hash};
 use std::ops::AddAssign;
 
-impl<T, N> Extend<T> for Counter<T, N>
+impl<T, N, S> Extend<T> for Counter<T, N, S>
 where
     T: Hash + Eq,
     N: AddAssign + Zero + One,
+    S: BuildHasher,
 {
     /// Extend a `Counter` with an iterator of items.
     ///
@@ -25,10 +26,11 @@ where
     }
 }
 
-impl<T, N> Extend<(T, N)> for Counter<T, N>
+impl<T, N, S> Extend<(T, N)> for Counter<T, N, S>
 where
     T: Hash + Eq,
     N: AddAssign + Zero,
+    S: BuildHasher,
 {
     /// Extend a counter with `(item, count)` tuples.
     ///
@@ -50,10 +52,11 @@ where
     }
 }
 
-impl<'a, T: 'a, N: 'a> Extend<(&'a T, &'a N)> for Counter<T, N>
+impl<'a, T: 'a, N: 'a, S> Extend<(&'a T, &'a N)> for Counter<T, N, S>
 where
     T: Hash + Eq + Clone,
     N: AddAssign + Zero + Clone,
+    S: BuildHasher,
 {
     /// Extend a counter with `(item, count)` tuples.
     ///

--- a/src/impls/from_iterator.rs
+++ b/src/impls/from_iterator.rs
@@ -2,14 +2,15 @@ use crate::Counter;
 
 use num_traits::{One, Zero};
 
-use std::hash::Hash;
+use std::hash::{BuildHasher, Hash};
 use std::iter;
 use std::ops::AddAssign;
 
-impl<T, N> Counter<T, N>
+impl<T, N, S> Counter<T, N, S>
 where
     T: Hash + Eq,
     N: AddAssign + Zero + One,
+    S: BuildHasher + Default,
 {
     /// Create a new `Counter` initialized with the given iterable.
     #[deprecated = "prefer the `FromIterator`/`collect` interface"]
@@ -21,10 +22,11 @@ where
     }
 }
 
-impl<T, N> iter::FromIterator<T> for Counter<T, N>
+impl<T, N, S> iter::FromIterator<T> for Counter<T, N, S>
 where
     T: Hash + Eq,
     N: AddAssign + Zero + One,
+    S: BuildHasher + Default,
 {
     /// Produce a `Counter` from an iterator of items. This is called automatically
     /// by [`Iterator::collect()`].

--- a/src/impls/index.rs
+++ b/src/impls/index.rs
@@ -3,14 +3,15 @@ use crate::Counter;
 use num_traits::Zero;
 
 use std::borrow::Borrow;
-use std::hash::Hash;
+use std::hash::{BuildHasher, Hash};
 use std::ops::{Index, IndexMut};
 
-impl<T, Q, N> Index<&'_ Q> for Counter<T, N>
+impl<T, Q, N, S> Index<&'_ Q> for Counter<T, N, S>
 where
     T: Hash + Eq + Borrow<Q>,
     Q: Hash + Eq,
     N: Zero,
+    S: BuildHasher,
 {
     type Output = N;
 
@@ -48,11 +49,12 @@ where
     }
 }
 
-impl<T, Q, N> IndexMut<&'_ Q> for Counter<T, N>
+impl<T, Q, N, S> IndexMut<&'_ Q> for Counter<T, N, S>
 where
     T: Hash + Eq + Borrow<Q>,
     Q: Hash + Eq + ToOwned<Owned = T>,
     N: Zero,
+    S: BuildHasher,
 {
     /// Index in mutable contexts.
     ///

--- a/src/impls/intersection.rs
+++ b/src/impls/intersection.rs
@@ -2,15 +2,16 @@ use crate::Counter;
 
 use num_traits::Zero;
 
-use std::hash::Hash;
+use std::hash::{BuildHasher, Hash};
 use std::ops::{BitAnd, BitAndAssign};
 
-impl<T, N> BitAnd for Counter<T, N>
+impl<T, N, S> BitAnd for Counter<T, N, S>
 where
     T: Hash + Eq,
     N: Ord + Zero,
+    S: BuildHasher + Default,
 {
-    type Output = Counter<T, N>;
+    type Output = Counter<T, N, S>;
 
     /// Returns the intersection of `self` and `rhs` as a new `Counter`.
     ///
@@ -27,7 +28,7 @@ where
     /// let expect = [('a', 1), ('b', 1)].iter().cloned().collect::<HashMap<_, _>>();
     /// assert_eq!(e.into_map(), expect);
     /// ```
-    fn bitand(self, mut rhs: Counter<T, N>) -> Self::Output {
+    fn bitand(self, mut rhs: Counter<T, N, S>) -> Self::Output {
         use std::cmp::min;
 
         let mut counter = Counter::new();
@@ -41,10 +42,11 @@ where
     }
 }
 
-impl<T, N> BitAndAssign for Counter<T, N>
+impl<T, N, S> BitAndAssign for Counter<T, N, S>
 where
     T: Hash + Eq,
     N: Ord + Zero,
+    S: BuildHasher,
 {
     /// Updates `self` with the intersection of `self` and `rhs`
     ///
@@ -61,7 +63,7 @@ where
     /// let expect = [('a', 1), ('b', 1)].iter().cloned().collect::<HashMap<_, _>>();
     /// assert_eq!(c.into_map(), expect);
     /// ```
-    fn bitand_assign(&mut self, mut rhs: Counter<T, N>) {
+    fn bitand_assign(&mut self, mut rhs: Counter<T, N, S>) {
         for (key, rhs_count) in rhs.drain() {
             if rhs_count < self[&key] {
                 self.map.insert(key, rhs_count);

--- a/src/impls/into_iterator.rs
+++ b/src/impls/into_iterator.rs
@@ -1,6 +1,6 @@
 use crate::Counter;
 
-impl<'a, T, N> IntoIterator for &'a Counter<T, N> {
+impl<'a, T, N, S> IntoIterator for &'a Counter<T, N, S> {
     type Item = (&'a T, &'a N);
     type IntoIter = std::collections::hash_map::Iter<'a, T, N>;
 
@@ -9,7 +9,7 @@ impl<'a, T, N> IntoIterator for &'a Counter<T, N> {
     }
 }
 
-impl<T, N> IntoIterator for Counter<T, N> {
+impl<T, N, S> IntoIterator for Counter<T, N, S> {
     type Item = (T, N);
     type IntoIter = std::collections::hash_map::IntoIter<T, N>;
 
@@ -37,7 +37,7 @@ impl<T, N> IntoIterator for Counter<T, N> {
     }
 }
 
-impl<'a, T, N> IntoIterator for &'a mut Counter<T, N> {
+impl<'a, T, N, S> IntoIterator for &'a mut Counter<T, N, S> {
     type Item = (&'a T, &'a mut N);
     type IntoIter = std::collections::hash_map::IterMut<'a, T, N>;
 

--- a/src/impls/serialize.rs
+++ b/src/impls/serialize.rs
@@ -5,7 +5,7 @@ use serde::{de::Deserializer, ser::Serializer, Deserialize, Serialize};
 
 use crate::Counter;
 
-impl<T, N> Serialize for Counter<T, N>
+impl<T, N, St> Serialize for Counter<T, N, St>
 where
     T: Serialize,
     N: Serialize,
@@ -18,10 +18,11 @@ where
     }
 }
 
-impl<'de, T, N> Deserialize<'de> for Counter<T, N>
+impl<'de, T, N, St> Deserialize<'de> for Counter<T, N, St>
 where
     T: Deserialize<'de> + Hash + Eq,
     N: Deserialize<'de> + Zero,
+    St: Default,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/src/impls/sub_iterable.rs
+++ b/src/impls/sub_iterable.rs
@@ -2,14 +2,15 @@ use crate::Counter;
 
 use num_traits::{One, Zero};
 
-use std::hash::Hash;
+use std::hash::{BuildHasher, Hash};
 use std::ops::{Sub, SubAssign};
 
-impl<I, T, N> Sub<I> for Counter<T, N>
+impl<I, T, N, S> Sub<I> for Counter<T, N, S>
 where
     I: IntoIterator<Item = T>,
     T: Hash + Eq,
     N: PartialOrd + SubAssign + Zero + One,
+    S: BuildHasher,
 {
     type Output = Self;
     /// Consume `self` producing a `Counter` like `self` with the counts of the

--- a/src/impls/sub_self.rs
+++ b/src/impls/sub_self.rs
@@ -2,15 +2,16 @@ use crate::Counter;
 
 use num_traits::Zero;
 
-use std::hash::Hash;
+use std::hash::{BuildHasher, Hash};
 use std::ops::{Sub, SubAssign};
 
-impl<T, N> Sub for Counter<T, N>
+impl<T, N, S> Sub for Counter<T, N, S>
 where
     T: Hash + Eq,
     N: PartialOrd + PartialEq + SubAssign + Zero,
+    S: BuildHasher,
 {
-    type Output = Counter<T, N>;
+    type Output = Counter<T, N, S>;
 
     /// Subtract (keeping only positive values).
     ///
@@ -31,16 +32,17 @@ where
     /// let expect = [('a', 2)].iter().cloned().collect::<HashMap<_, _>>();
     /// assert_eq!(e.into_map(), expect);
     /// ```
-    fn sub(mut self, rhs: Counter<T, N>) -> Self::Output {
+    fn sub(mut self, rhs: Counter<T, N, S>) -> Self::Output {
         self -= rhs;
         self
     }
 }
 
-impl<T, N> SubAssign for Counter<T, N>
+impl<T, N, S> SubAssign for Counter<T, N, S>
 where
     T: Hash + Eq,
     N: PartialOrd + PartialEq + SubAssign + Zero,
+    S: BuildHasher,
 {
     /// Subtract (keeping only positive values).
     ///

--- a/src/impls/union.rs
+++ b/src/impls/union.rs
@@ -2,15 +2,16 @@ use crate::Counter;
 
 use num_traits::Zero;
 
-use std::hash::Hash;
+use std::hash::{BuildHasher, Hash};
 use std::ops::{BitOr, BitOrAssign};
 
-impl<T, N> BitOr for Counter<T, N>
+impl<T, N, S> BitOr for Counter<T, N, S>
 where
     T: Hash + Eq,
     N: Ord + Zero,
+    S: BuildHasher,
 {
-    type Output = Counter<T, N>;
+    type Output = Counter<T, N, S>;
 
     /// Returns the union of `self` and `rhs` as a new `Counter`.
     ///
@@ -27,7 +28,7 @@ where
     /// let expect = [('a', 3), ('b', 2)].iter().cloned().collect::<HashMap<_, _>>();
     /// assert_eq!(e.into_map(), expect);
     /// ```
-    fn bitor(mut self, rhs: Counter<T, N>) -> Self::Output {
+    fn bitor(mut self, rhs: Counter<T, N, S>) -> Self::Output {
         for (key, rhs_value) in rhs.map {
             let entry = self.map.entry(key).or_insert_with(N::zero);
             // We want to update the value of the now occupied entry in `self` with the maximum of
@@ -54,10 +55,11 @@ where
     }
 }
 
-impl<T, N> BitOrAssign for Counter<T, N>
+impl<T, N, S> BitOrAssign for Counter<T, N, S>
 where
     T: Hash + Eq,
     N: Ord + Zero,
+    S: BuildHasher,
 {
     /// Updates `self` with the union of `self` and `rhs`
     ///
@@ -74,7 +76,7 @@ where
     /// let expect = [('a', 3), ('b', 2)].iter().cloned().collect::<HashMap<_, _>>();
     /// assert_eq!(c.into_map(), expect);
     /// ```
-    fn bitor_assign(&mut self, mut rhs: Counter<T, N>) {
+    fn bitor_assign(&mut self, mut rhs: Counter<T, N, S>) {
         for (key, rhs_count) in rhs.drain() {
             if rhs_count > self[&key] {
                 self.map.insert(key, rhs_count);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,23 +280,24 @@ mod impls;
 use num_traits::{One, Zero};
 
 use std::collections::{BinaryHeap, HashMap};
-use std::hash::Hash;
+use std::hash::{BuildHasher, Hash, RandomState};
 use std::iter;
 use std::ops::{AddAssign, SubAssign};
 #[cfg(test)]
 mod unit_tests;
 
 #[derive(Clone, Debug)]
-pub struct Counter<T, N = usize> {
-    map: HashMap<T, N>,
+pub struct Counter<T, N = usize, S = RandomState> {
+    map: HashMap<T, N, S>,
     // necessary for `Index::index` since we cannot declare generic `static` variables.
     zero: N,
 }
 
-impl<T, N> PartialEq for Counter<T, N>
+impl<T, N, S> PartialEq for Counter<T, N, S>
 where
     T: Eq + Hash,
     N: PartialEq,
+    S: BuildHasher,
 {
     fn eq(&self, other: &Self) -> bool {
         // ignore the zero
@@ -304,10 +305,11 @@ where
     }
 }
 
-impl<T, N> Eq for Counter<T, N>
+impl<T, N, S> Eq for Counter<T, N, S>
 where
     T: Eq + Hash,
     N: Eq,
+    S: BuildHasher,
 {
 }
 
@@ -342,10 +344,11 @@ impl<T, N> Counter<T, N> {
     }
 }
 
-impl<T, N> Counter<T, N>
+impl<T, N, S> Counter<T, N, S>
 where
     T: Hash + Eq,
     N: AddAssign + Zero + One,
+    S: BuildHasher,
 {
     /// Add the counts of the elements from the given iterable to this counter.
     pub fn update<I>(&mut self, iterable: I)
@@ -359,10 +362,11 @@ where
     }
 }
 
-impl<T, N> Counter<T, N>
+impl<T, N, S> Counter<T, N, S>
 where
     T: Hash + Eq,
     N: PartialOrd + SubAssign + Zero + One,
+    S: BuildHasher,
 {
     /// Remove the counts of the elements from the given iterable to this counter.
     ///
@@ -395,7 +399,7 @@ where
     }
 }
 
-impl<T, N> Counter<T, N>
+impl<T, N, S> Counter<T, N, S>
 where
     T: Hash + Eq + Clone,
     N: Clone + Ord,
@@ -447,7 +451,7 @@ where
     }
 }
 
-impl<T, N> Counter<T, N>
+impl<T, N, S> Counter<T, N, S>
 where
     T: Hash + Eq + Clone + Ord,
     N: Clone + Ord,
@@ -556,10 +560,11 @@ where
     }
 }
 
-impl<T, N> Counter<T, N>
+impl<T, N, S> Counter<T, N, S>
 where
     T: Hash + Eq,
     N: PartialOrd + Zero,
+    S: BuildHasher,
 {
     /// Test whether this counter is a superset of another counter.
     /// This is true if for all elements in this counter and the other,


### PR DESCRIPTION
Attempts to close #32. Still needs documentation etc, but figured I'd get the initial PR up for code review.

I'm fairly new to rust so feel free to be brutal here! It's likely that I'm missing something obvious here.

I was looking into whether it would be plausible to also be generic over the map type (say, to allow `BTreeMap` instead of `HashMap` which might be handy when it comes to things like `k_most_common`, but was struggling to see how to make it be generic over both.