### PR TITLE
fix: build with serde enabled

### DIFF
--- a/src/impls/serialize.rs
+++ b/src/impls/serialize.rs
@@ -1,4 +1,4 @@
-use std::hash::Hash;
+use std::hash::{BuildHasher, Hash};
 
 use num_traits::Zero;
 use serde::{de::Deserializer, ser::Serializer, Deserialize, Serialize};
@@ -22,7 +22,7 @@ impl<'de, T, N, St> Deserialize<'de> for Counter<T, N, St>
 where
     T: Deserialize<'de> + Hash + Eq,
     N: Deserialize<'de> + Zero,
-    St: Default,
+    St: Default + BuildHasher,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where


### PR DESCRIPTION
- build with `serde` enabled was failing
```
> cargo build --features "serde"
  Downloaded serde_core v1.0.228
  Downloaded serde v1.0.228
  Downloaded 2 crates (146.8 KB) in 0.15s
   Compiling serde_core v1.0.228
   Compiling serde v1.0.228
   Compiling num-traits v0.2.19
   Compiling counter v0.7.0 (/Users/govinda/Code/counter-rs)
error[E0277]: the trait bound `St: BuildHasher` is not satisfied
  --> src/impls/serialize.rs:31:20
   |
31 |         let map = <_>::deserialize(deserializer)?;
   |                    ^ the trait `BuildHasher` is not implemented for `St`, which is required by `HashMap<T, N, St>: Deserialize<'_>`
   |
   = note: required for `HashMap<T, N, St>` to implement `Deserialize<'_>`
help: consider further restricting this bound
   |
25 |     St: Default + std::hash::BuildHasher,
   |                 ++++++++++++++++++++++++

For more information about this error, try `rustc --explain E0277`.
error: could not compile `counter` (lib) due to 1 previous error
```

- restricting the trait to have `BuildHasher` fixes it.